### PR TITLE
Critical Bugfix, NBT Tags for Items, QoL changes

### DIFF
--- a/src/main/java/net/roxeez/advancement/AdvancementManager.java
+++ b/src/main/java/net/roxeez/advancement/AdvancementManager.java
@@ -63,6 +63,16 @@ public class AdvancementManager {
         Advancement advancement = creator.create(new Context(plugin, advancements));
         this.advancements.put(advancement.getKey(), advancement);
     }
+    
+    /**
+     * Registers an Advancement
+     * 
+     * @param advancement The Advancement to register
+     */
+    public void register(@NotNull Advancement advancement) {
+        Preconditions.checkNotNull(advancement);
+        advancements.put(advancement.getKey(), advancement);
+    }
 
     /**
      * Create all registered advancements

--- a/src/main/java/net/roxeez/advancement/AdvancementManager.java
+++ b/src/main/java/net/roxeez/advancement/AdvancementManager.java
@@ -8,6 +8,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import java.util.Map;
 public class AdvancementManager {
 
     private final Plugin plugin;
-    private final ObjectSerializer serializer  = new ObjectSerializer();
+    private final ObjectSerializer serializer = new ObjectSerializer();
     private final Map<NamespacedKey, Advancement> advancements = new LinkedHashMap<>();
 
     /**
@@ -44,7 +45,6 @@ public class AdvancementManager {
      * Get a registered advancement of this plugin by id
      *
      * @param id Id of this advancement
-     *
      * @return Advancement with this id or null if none
      */
     @Nullable
@@ -63,10 +63,10 @@ public class AdvancementManager {
         Advancement advancement = creator.create(new Context(plugin, advancements));
         this.advancements.put(advancement.getKey(), advancement);
     }
-    
+
     /**
      * Registers an Advancement
-     * 
+     *
      * @param advancement The Advancement to register
      */
     public void register(@NotNull Advancement advancement) {
@@ -76,24 +76,27 @@ public class AdvancementManager {
 
     /**
      * Create all registered advancements
+     *
+     * @param clean If previously generated advancements should be removed.
      */
-    public void createAll()
-    {
-        plugin.getLogger().info("[AdvancementAPI] Cleaning previously generated advancements");
-        for(Advancement advancement : this.advancements.values())
-        {
-            if (Bukkit.getAdvancement(advancement.getKey()) != null)
-            {
-                Bukkit.getUnsafe().removeAdvancement(advancement.getKey());
+    @SuppressWarnings("deprecation")
+    public void createAll(boolean clean) {
+        if (clean) {
+            plugin.getLogger().info("[AdvancementAPI] Cleaning previously generated advancements");
+            for (Advancement advancement : this.advancements.values()) {
+                if (Bukkit.getAdvancement(advancement.getKey()) != null) {
+                    Bukkit.getUnsafe().removeAdvancement(advancement.getKey());
+                }
             }
+
+            Bukkit.reloadData();
         }
 
-        Bukkit.reloadData();
-
         plugin.getLogger().info("[AdvancementAPI] Generating advancements");
-        for(Advancement advancement : this.advancements.values())
-        {
-            Bukkit.getUnsafe().loadAdvancement(advancement.getKey(), serializer.serialize(advancement));
+        for (Advancement advancement : this.advancements.values()) {
+            if (Bukkit.getAdvancement(advancement.getKey()) == null) {
+                Bukkit.getUnsafe().loadAdvancement(advancement.getKey(), serializer.serialize(advancement));
+            }
         }
 
         Bukkit.reloadData();

--- a/src/main/java/net/roxeez/advancement/AdvancementManager.java
+++ b/src/main/java/net/roxeez/advancement/AdvancementManager.java
@@ -8,7 +8,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -18,7 +18,7 @@ public class AdvancementManager {
 
     private final Plugin plugin;
     private final ObjectSerializer serializer  = new ObjectSerializer();
-    private final Map<NamespacedKey, Advancement> advancements = new HashMap<>();
+    private final Map<NamespacedKey, Advancement> advancements = new LinkedHashMap<>();
 
     /**
      * Create a new AdvancementManager instance for this plugin

--- a/src/main/java/net/roxeez/advancement/data/ItemData.java
+++ b/src/main/java/net/roxeez/advancement/data/ItemData.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import org.bukkit.Material;
 
-// TODO : Add enchantments, stored_enchantments, nbt, tag
+// TODO : Add enchantments, stored_enchantments, tag
 public class ItemData {
 
     @Expose
@@ -22,6 +22,10 @@ public class ItemData {
     @Expose
     @SerializedName("potion")
     private PotionType potion;
+    
+    @Expose
+    @SerializedName("nbt")
+    private String nbt;
 
     public void setType(Material material) {
         this.item = material;
@@ -46,5 +50,9 @@ public class ItemData {
     public void setPotion(PotionType potion) {
         this.potion = potion;
     }
-
+    
+    public void setNbt(String nbt) {
+        this.nbt = nbt;
+    }
+    
 }

--- a/src/main/java/net/roxeez/advancement/display/Display.java
+++ b/src/main/java/net/roxeez/advancement/display/Display.java
@@ -159,7 +159,7 @@ public class Display {
      *
      * @param toast True if displayed false if not
      */
-    public void toast(boolean toast) {
+    public void setToast(boolean toast) {
         this.toast = toast;
     }
 
@@ -168,7 +168,7 @@ public class Display {
      *
      * @param announce True if yes false if not
      */
-    public void announce(boolean announce) {
+    public void setAnnounce(boolean announce) {
         this.announce = announce;
     }
 
@@ -177,7 +177,7 @@ public class Display {
      *
      * @param hidden True if hidden false if visible
      */
-    public void hidden(boolean hidden) {
+    public void setHidden(boolean hidden) {
         this.hidden = hidden;
     }
 

--- a/src/main/java/net/roxeez/advancement/display/Display.java
+++ b/src/main/java/net/roxeez/advancement/display/Display.java
@@ -100,6 +100,16 @@ public class Display {
     }
 
     /**
+     * Set the icon of this advancement
+     * 
+     * @param icon The icon of this advancement
+     */
+    public void setIcon(@NotNull Icon icon) {
+        Preconditions.checkNotNull(icon);
+        this.icon = icon;
+    }
+
+    /**
      * Set icon of this advancement
      * This method will set icon and then call provided consumer on it
      *

--- a/src/main/java/net/roxeez/advancement/display/Display.java
+++ b/src/main/java/net/roxeez/advancement/display/Display.java
@@ -114,17 +114,22 @@ public class Display {
     }
 
     /**
-     * Shortcut to only set and item as icon
+     * Shortcut to only set an item as icon
      *
      * @param material Item of advancement icon
      */
     public void setIcon(@NotNull Material material) {
-        Preconditions.checkNotNull(material);
-
-        Icon icon = new Icon();
-        icon.setItem(material);
-
-        this.icon = icon;
+        this.icon = new Icon(material, null);
+    }
+    
+    /**
+     * Shortcut to only set an item with NBT values as icon
+     *
+     * @param material Item of advancement icon
+     * @param nbt NBT values of the advancement icon
+     */
+    public void setIcon(@NotNull Material material, String nbt) {
+        this.icon = new Icon(material, nbt);
     }
 
     /**

--- a/src/main/java/net/roxeez/advancement/display/Icon.java
+++ b/src/main/java/net/roxeez/advancement/display/Icon.java
@@ -18,7 +18,29 @@ public class Icon {
     @Expose
     @SerializedName("item")
     private NamespacedKey item;
-
+    
+    /**
+     * NBT values of displayed item in this icon
+     */
+    @Expose
+    @SerializedName("nbt")
+    private String nbt;
+    
+    public Icon() {
+    }
+    
+    public Icon(@NotNull NamespacedKey item, String nbt) {
+        Preconditions.checkNotNull(item);
+        this.item = item;
+        this.nbt = nbt;
+    }
+    
+    public Icon(@NotNull Material material, String nbt) {
+        Preconditions.checkNotNull(material);
+        this.item = material.getKey();
+        this.nbt = nbt;
+    }
+    
     /**
      * Set item shown in this icon
      *
@@ -28,5 +50,14 @@ public class Icon {
         Preconditions.checkNotNull(material);
         this.item = material.getKey();
     }
-
+    
+    /**
+     * Set the NBT values of the icon
+     * 
+     * @param nbt NBT values of the displayed icon
+     */
+    public void setNbt(String nbt) {
+        this.nbt = nbt;
+    }
+    
 }


### PR DESCRIPTION
You used a HashMap in the AdvancementManager, which lead to advancements being registered in the wrong order. This meant that sometimes advancements could not be registered because their parent didn't exist yet. I fixed that by changing the HashMap to a LinkedHashMap.

I also added some methods for NBT Data in Items. Both Icon and ItemData do now accept NBT Data.

Additonally, I added some methods / parameters for methods that I felt like were really needed, like an option to not clean up all previously generated advancements when registering them.

Finally, I renamed the setter methods in the Display Class to have the "set" Prefix.