### PR TITLE
Fix CHALLENGE advancement display type being exposed with the wrong name

### DIFF
--- a/src/main/java/net/roxeez/advancement/display/FrameType.java
+++ b/src/main/java/net/roxeez/advancement/display/FrameType.java
@@ -4,7 +4,7 @@ package net.roxeez.advancement.display;
  * Represent all possible advancement frame
  */
 public enum FrameType {
-    CHALLENGER("challenger"),
+    CHALLENGE("challenge"),
     TASK("task"),
     GOAL("goal");
 


### PR DESCRIPTION
The `CHALLENGE` FrameType is incorrectly included as `CHALLENGER` (with a trailing 'R'). This isn't (and has never been afaik) a valid [AdvancementDisplayType](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/advancement/AdvancementDisplayType.html) -- I think it's a typo :-)? Currently, passing `FrameType.CHALLENGER` throws an exception as the Spigot API is unable to resolve the correct type.
This PR corrects this.