### PR TITLE
Add AdvancementsCreateEvent

### DIFF
--- a/src/main/java/net/roxeez/advancement/AdvancementManager.java
+++ b/src/main/java/net/roxeez/advancement/AdvancementManager.java
@@ -2,6 +2,7 @@ package net.roxeez.advancement;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import net.roxeez.advancement.event.AdvancementsCreateEvent;
 import net.roxeez.advancement.serialization.ObjectSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -100,6 +101,7 @@ public class AdvancementManager {
         }
 
         Bukkit.reloadData();
+        Bukkit.getServer().getPluginManager().callEvent(new AdvancementsCreateEvent());
     }
 
 }

--- a/src/main/java/net/roxeez/advancement/event/AdvancementsCreateEvent.java
+++ b/src/main/java/net/roxeez/advancement/event/AdvancementsCreateEvent.java
@@ -1,0 +1,25 @@
+package net.roxeez.advancement.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when the advancements are registered and Bukkit data is reloaded
+ */
+public class AdvancementsCreateEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    @Override
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}


### PR DESCRIPTION
This will allow plugins that register custom recipes to register the recipes after the Bukkit Data is reloaded so that they are not reset. If the recipes are registered before the advancements, than the recipes will be removed.